### PR TITLE
Fix code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/assets/vendor/php-email-form/validate.js
+++ b/assets/vendor/php-email-form/validate.js
@@ -6,6 +6,15 @@
 (function () {
   "use strict";
 
+  function escapeHtml(unsafe) {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   let forms = document.querySelectorAll('.php-email-form');
 
   forms.forEach( function(e) {
@@ -78,7 +87,7 @@
 
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').innerHTML = escapeHtml(error);
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Fixes [https://github.com/InvalidSoul69/roots.org/security/code-scanning/1](https://github.com/InvalidSoul69/roots.org/security/code-scanning/1)

To fix the problem, we need to ensure that any error messages displayed on the webpage are properly sanitized to prevent XSS attacks. The best way to do this is to escape any HTML special characters in the error message before setting it as the innerHTML of an element.

We can create a utility function to escape HTML special characters and use this function to sanitize the error message before displaying it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
